### PR TITLE
Minimum node version is 8 because of trailing commas used in project …

### DIFF
--- a/build-tools/start-dev-server.js
+++ b/build-tools/start-dev-server.js
@@ -5,8 +5,6 @@
  *
  * Please note: This file is not parsed through webpack but directly executed by Node.JS
  */
-const path = require('path');
-
 const WebpackDevCompiler = require('./webpack-dev-compiler');
 const webOptions = require('.//config/buildoptions/web-dev.buildoptions');
 const nodeOptions = require('.//config/buildoptions/node-dev.buildoptions');

--- a/build-tools/start-dev-server.js
+++ b/build-tools/start-dev-server.js
@@ -14,7 +14,7 @@ const nodeVersion = process.version.replace(/^[^0-9]+/, '');
 const nodeMajorVersion = parseInt(nodeVersion[0], 10);
 const argv = require('yargs').argv;
 
-if (!argv['legacy-node'] && nodeMajorVersion < 6) {
+if (!argv['legacy-node'] && nodeMajorVersion < 8) {
   throw new Error(
     'You need at least NodeJS v6.0 to run this dev server. Current NodeJS version is ' +
       nodeMajorVersion,


### PR DESCRIPTION
Current version check in start-dev-server has a old version of node specified. Will not run on node 7 only 8 because of trailing commas in code.